### PR TITLE
chore: 임시로 배포환경에서 MSW 활성화

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_USE_MSW=

--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ coverage
 *.njsproj
 *.sln
 *.sw?
+
+.env*
+!.env.example

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,11 +3,18 @@ import { createRoot } from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
 
-// MSW dev 환경에서만 실행
-if (import.meta.env.DEV) {
-  const { worker } = await import('./mocks/browser.ts');
-  worker.start();
+async function prepareMockWorker() {
+  // MSW dev 환경에서만 실행
+  if (import.meta.env.MODE === 'development' || import.meta.env.VITE_USE_MSW === 'true') {
+    const { worker } = await import('./mocks/browser');
+    await worker.start();
+
+    // MSW 활성화 로그 출력
+    console.log('%c[MSW] Mock Service Worker is running.', 'color: green; font-weight: bold;');
+  }
 }
+
+prepareMockWorker();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>


### PR DESCRIPTION
VITE_ENV_MSW 환경변수 설정

- MSW가 dev 환경에서만 동작하도록 되어 있어 배포환경에서는 로딩만 뜨는 문제 발생
- 개발/테스트 확인을 위해 `.env.production`에 VITE_USE_MSW=true 추가
- main.tsx에서 해당 값을 기반으로 MSW 활성화